### PR TITLE
WL-2866 Fix the groupId from the accidental change.

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -41,7 +41,7 @@
 		</dependency>
 		
 		<dependency>
-			<groupId>uk.ac.ox.oucs.vle</groupId>
+			<groupId>uk.ac.ox.oucs</groupId>
 			<artifactId>course-signup-ldap</artifactId>
 			<version>1.0-SNAPSHOT</version>
 		</dependency>


### PR DESCRIPTION
In WL-2355 I accidentally changed the groupId of the LDAP artifact, this resulted in normal builds continuing to work but clean builds failing. This switches the component to use the new groupId.
