### PR TITLE
WL-66 Allow principal to come from config.

### DIFF
--- a/kerberos/src/java/org/sakaiproject/component/kerberos/user/JassAuthenticate.java
+++ b/kerberos/src/java/org/sakaiproject/component/kerberos/user/JassAuthenticate.java
@@ -118,8 +118,14 @@ public class JassAuthenticate {
 				log.debug("Authenticated ok and not attempting service ticket verification");
 				return true;
 			}
+			// The server principal used to create the login context has to use a / rather than a @.
+			// It would be much cleaner to just have the passed config use the traditional / and then
+			// replace it to a @ for the GSS code.
+			String serverPrincipal = serverGSS.replaceFirst("@", "/");
 			// Shouldn't ever fail
-			serverLoginContext = new LoginContext(servicePrincipal, new NullCallbackHandler());
+			// We want to specify the principal to use so our JAAS config doesn't have to contain it.
+			serverLoginContext = new LoginContext(servicePrincipal, new UsernamePasswordCallback(serverPrincipal, null));
+
 			serverLoginContext.login();
 
 			GSSManager manager = GSSManager.getInstance();

--- a/kerberos/src/java/org/sakaiproject/component/kerberos/user/UsernamePasswordCallback.java
+++ b/kerberos/src/java/org/sakaiproject/component/kerberos/user/UsernamePasswordCallback.java
@@ -46,10 +46,10 @@ public class UsernamePasswordCallback implements CallbackHandler {
 	public void handle(Callback[] callbacks) throws IOException,
 			UnsupportedCallbackException {
 		for (Callback callback : callbacks) {
-			if (callback instanceof NameCallback) {
+			if (callback instanceof NameCallback && username != null) {
 				NameCallback nameCallback = (NameCallback) callback;
 				nameCallback.setName(username);
-			} else if (callback instanceof PasswordCallback) {
+			} else if (callback instanceof PasswordCallback && password != null) {
 				PasswordCallback passwordCallback = (PasswordCallback) callback;
 				passwordCallback.setPassword(password.toCharArray());
 			} else {


### PR DESCRIPTION
Normally we would embed the principal to use when validating a service ticket inside the sakai-jaas.conf file. This worked however as this principal is specific to each service we end up having a sakai-jaas.conf for each deployment. With the switch to docker it would be much cleaner if sakai-jaas.conf was the same everywhere (and embedded in the image) and the principal to use was pulled from the sakai configuration.
