### PR TITLE
WL-3781 Update course groups on login to Sakai.

### DIFF
--- a/jldap/src/java/edu/amc/sakai/user/JLDAPGroupProvider.java
+++ b/jldap/src/java/edu/amc/sakai/user/JLDAPGroupProvider.java
@@ -34,7 +34,7 @@ public class JLDAPGroupProvider implements GroupProvider {
 	private ProvidedGroupManager groupManager;
 	private JLDAPDirectoryProvider jldapDirectoryProvider;
 
-	private String searchBase = "ou=units,dc=oak,dc=ox,dc=ac,dc=uk";
+	private String searchBase = "dc=oak,dc=ox,dc=ac,dc=uk";
 	private String memberAttribute = "member";
 	private String personIdPattern = "oakPrimaryPersonID={0},ou=people,dc=oak,dc=ox,dc=ac,dc=uk";
 


### PR DESCRIPTION
Previously we were only searching for changed groups in the units part of the tree, this meant changes in course groups wouldn’t get pulled in quickly.
