### PR TITLE
WL-4174 Better LDAP connection validator.

### DIFF
--- a/component/src/webapp/WEB-INF/jldap-beans.xml
+++ b/component/src/webapp/WEB-INF/jldap-beans.xml
@@ -15,6 +15,30 @@
 		</property>
 	</bean>
 
+	<!-- We need our own connection manager so we can have better validators -->
+	<bean id="edu.amc.sakai.user.LdapConnectionManager"
+		  class="edu.amc.sakai.user.PoolingLdapConnectionManager">
+		<property name="factory">
+			<bean class="edu.amc.sakai.user.PooledLDAPConnectionFactory">
+				<property name="connectionLivenessValidator">
+					<bean class="edu.amc.sakai.user.ConsensusLdapConnectionLivenessValidator">
+						<property name="delegates">
+							<list>
+								<bean class="edu.amc.sakai.user.MaxLifetimeLdapConnectionLivenessValidator">
+									<!-- Only allow connections to last for a minute -->
+									<property name="maxTtl" value="60000"/>
+								</bean>
+								<bean class="edu.amc.sakai.user.NativeLdapConnectionLivenessValidator">
+									<!-- This catches correctly close connections -->
+								</bean>
+							</list>
+						</property>
+					</bean>
+				</property>
+			</bean>
+		</property>
+	</bean>
+
 	<bean id="edu.amc.sakai.user.JLDAPDirectoryProvider"
 		class="edu.amc.sakai.user.JLDAPDirectoryProvider" init-method="init"
 		destroy-method="destroy">
@@ -70,9 +94,10 @@
 			instance of com.novell.ldap.LDAPJSSESecureSocketFactory, which
 			is appropriate for SSL connections. Use 
 			com.novell.ldap.LDAPJSSEStartTLSFactory for TLS. -->
-		<!-- property name="secureSocketFactory">
-			<bean class="com.novell.ldap.LDAPJSSESecureSocketFactory" />
-		</property -->
+		<property name="secureSocketFactory">
+			<!-- This actually has a connect timeout -->
+            <bean class="edu.amc.sakai.user.LDAPJSSESecureSocketFactory"/>
+		</property>
 
 		<!-- Optional. Indicate if connection allocation should
 			implicitly bind as ${ldapUser}. Defaults to false -->
@@ -92,7 +117,7 @@
 			<value>false</value>
 		</property -->
 
-		<!-- Optional. LDAP operation timeout in millis. Defaults 
+		<!-- Optional. LDAP operation connectTimeout in millis. Defaults
 			to JLDAPDirectoryProvider.DEFAULT_OPERATION_TIMEOUT_MILLIS (5000) -->
 		<!-- property name="operationTimeout">
 			<value>5000</value>
@@ -136,9 +161,9 @@
 		
 		<!-- Optional. Defaults to an instance of 
 		edu.amc.sakai.user.SimpleLdapConnectionManager -->
-		<!-- property name="ldapConnectionManager">
-			<bean class="edu.amc.sakai.user.SimpleLdapConnectionManager" />
-		</property -->
+		<property name="ldapConnectionManager">
+			<ref bean="edu.amc.sakai.user.LdapConnectionManager" />
+		</property>
 
 		<!-- Optional. Use Connection Pooling?
 			Defaults to JLDAPDirectoryProvider.DEFAULT_POOLING (false). 

--- a/jldap/src/java/edu/amc/sakai/user/LDAPJSSESecureSocketFactory.java
+++ b/jldap/src/java/edu/amc/sakai/user/LDAPJSSESecureSocketFactory.java
@@ -1,0 +1,117 @@
+/* **************************************************************************
+ * $OpenLDAP$
+ *
+ * Copyright (C) 1999, 2000, 2001 Novell, Inc. All Rights Reserved.
+ *
+ * THIS WORK IS SUBJECT TO U.S. AND INTERNATIONAL COPYRIGHT LAWS AND
+ * TREATIES. USE, MODIFICATION, AND REDISTRIBUTION OF THIS WORK IS SUBJECT
+ * TO VERSION 2.0.1 OF THE OPENLDAP PUBLIC LICENSE, A COPY OF WHICH IS
+ * AVAILABLE AT HTTP://WWW.OPENLDAP.ORG/LICENSE.HTML OR IN THE FILE "LICENSE"
+ * IN THE TOP-LEVEL DIRECTORY OF THE DISTRIBUTION. ANY USE OR EXPLOITATION
+ * OF THIS WORK OTHER THAN AS AUTHORIZED IN VERSION 2.0.1 OF THE OPENLDAP
+ * PUBLIC LICENSE, OR OTHER PRIOR WRITTEN CONSENT FROM NOVELL, COULD SUBJECT
+ * THE PERPETRATOR TO CRIMINAL AND CIVIL LIABILITY.
+ ******************************************************************************/
+
+package edu.amc.sakai.user;
+
+import com.novell.ldap.LDAPSocketFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+
+/**
+ * Represents a socket factory that creates secure socket connections to
+ * LDAP servers using JSSE technology. Unlike the one in the JLDAP library this
+ * actually has a connection connectTimeout that is sensible in production.
+ * This modifies the standard one in the JLDAP library to specify a connect
+ * timeout so that we don't wait forever to connect to a server.
+ *
+ * @see LDAPConnection#LDAPConnection(LDAPSocketFactory)
+ * @see LDAPConnection#setSocketFactory
+ */
+public class LDAPJSSESecureSocketFactory
+        implements LDAPSocketFactory, org.ietf.ldap.LDAPSocketFactory
+{
+    private SocketFactory factory;
+    // The connectTimeout to make connections in.
+    private int connectTimeout = 5000;
+
+    /**
+     * Constructs an LDAPSecureSocketFactory object using the default provider
+     * for a JSSE SSLSocketFactory.
+     *
+     * <p>Setting the keystore for the default provider is specific to
+     * the provider implementation.  For Sun's JSSE provider, the property
+     * javax.net.ssl.truststore should be set to the path of a keystore that
+     * holds the trusted root certificate of the directory server.</P>
+     *
+     * For information on creating keystores see the keytool documentation on
+     * <a href="http://java.sun.com/j2se/1.4/docs/tooldocs/tools.html#security">
+     * Java 2, security tools</a>.
+     */
+    public LDAPJSSESecureSocketFactory()
+    {
+        factory = SSLSocketFactory.getDefault();
+        return;
+    }
+
+    /**
+     * Constructs an LDAPSocketFactory object using the
+     * SSLSocketFactory specified.
+     *
+     * For information on using the the SSLSocketFactory, see also
+     * <a href="http://java.sun.com/j2se/1.4/docs/api/javax/net/ssl/SSLSocketFactory.html">
+     * javax.net.ssl.SSLSocketFactory</a>
+     */
+    public LDAPJSSESecureSocketFactory(SSLSocketFactory factory)
+    {
+        this.factory = factory;
+        return;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    /**
+     * Returns the socket connected to the LDAP server with the specified
+     * host name and port number.
+     *
+     * <p>The secure connection is established to the server when this
+     * call returns.  This method is called by the constructor of LDAPConnection
+     * </p>
+     *
+     * @param host The host name or a dotted string representing the IP address
+     *             of the LDAP server to which you want to establish
+     *             a connection.
+     *<br><br>
+     * @param port The port number on the specified LDAP server that you want to
+     *             use for this connection. The default LDAP port for SSL
+     *             connections is 636.
+     *
+     * @return A socket to the LDAP server using the specific host name and
+     *         port number.
+     *
+     * @exception IOException A socket to the specified host and port
+     *                          could not be created.
+     *
+     * @exception UnknownHostException The specified host could not be found.
+     */
+    public java.net.Socket createSocket(String host, int port)
+            throws IOException, UnknownHostException
+    {
+        Socket socket = factory.createSocket();
+        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        return factory.createSocket(host, port);
+    }
+}

--- a/jldap/src/java/edu/amc/sakai/user/NativeLdapConnectionLivenessValidator.java
+++ b/jldap/src/java/edu/amc/sakai/user/NativeLdapConnectionLivenessValidator.java
@@ -26,19 +26,28 @@ import org.apache.commons.logging.LogFactory;
 
 import com.novell.ldap.LDAPConnection;
 
-public class NativeLdapConnectionLivenessValidator 
+/**
+ * This doesn't appear to notice when a connection is stalling and continues to
+ * say that's it's ok. However what it does catch is a connection that has been
+ * closed by the server.
+ */
+public class NativeLdapConnectionLivenessValidator
 implements LdapConnectionLivenessValidator {
 
 	/** Class-specific logger */
 	private static Log log = LogFactory.getLog(NativeLdapConnectionLivenessValidator.class);
 	
 	public boolean isConnectionAlive(LDAPConnection connectionToTest) {
-		if ( log.isDebugEnabled() ) {
-			log.debug("isConnectionAlive(): attempting native liveness test");
+		if ( log.isTraceEnabled() ) {
+			log.trace("isConnectionAlive(): attempting native liveness test");
 		}
 		boolean isAlive = connectionToTest.isConnectionAlive();
-		if ( log.isDebugEnabled() ) {
-			log.debug("isConnectionAlive(): native liveness test result [" + isAlive + "]");
+
+		if ( log.isTraceEnabled() ) {
+			log.trace("isConnectionAlive(): native liveness test result [" + isAlive + "]");
+		}
+		if (!isAlive && log.isDebugEnabled()) {
+			log.debug("Connection to "+ connectionToTest.getHost()+ " is down.");
 		}
 		return isAlive;
 	}


### PR DESCRIPTION
We limit the connect timeout when creating new sockets so that when attempting to make a new connection if one of the servers is down we give up after 5 seconds and try another one. Otherwise we only every try one server. We don’t wait forever when attempting to create a new connection as there is a 60 second limit on the pool for creating a new object.

We also limit the lifetime of a LDAP connection to 60 seconds this is for the case when a connections gets shut down with being correctly closed. In this case we will just have to wait for the bad connections to become evicted from the pool.
